### PR TITLE
ON-34619 # Changed enabled and actions to required

### DIFF
--- a/typescript/scheduledTasks.ts
+++ b/typescript/scheduledTasks.ts
@@ -39,8 +39,8 @@ export interface NewTask {
         }
   }
   description?: string
-  enabled?: boolean
-  actions?: TaskAction[]
+  enabled: boolean
+  actions: TaskAction[]
 }
 export type Task = NewTask & {
   id: number


### PR DESCRIPTION
No `actions` can be represented by an empty array and having `enabled` as optional is ambiguous for what `undefined` means.