### PR TITLE
Revert "AP-9206 # Add `developerToolsConfiguration` migration options"

### DIFF
--- a/typescript/environments.d.ts
+++ b/typescript/environments.d.ts
@@ -138,9 +138,6 @@ export interface FormMigrationOptions {
   externalIdGenerationOnSubmit: boolean
   personalisation: boolean
   customPDFs: boolean
-  pointAddressEnvironmentId?: string
-  pointAddressV3EnvironmentId?: string
-  allowGeoscapeAddresses?: boolean
   embeddedForms?: Array<{
     sourceElementId: string
     targetFormId: number


### PR DESCRIPTION
Reverts oneblink/types#739

Closes AP-9590

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-definition-only revert with no runtime or security impact; consumers that relied on these migration options may need to adjust typings.
> 
> **Overview**
> Reverts the **AP-9206** change that extended `FormMigrationOptions` with developer-tools / point-address migration flags.
> 
> `FormMigrationOptions` in `environments.d.ts` no longer includes the optional fields `pointAddressEnvironmentId`, `pointAddressV3EnvironmentId`, and `allowGeoscapeAddresses`. Form-level types elsewhere (e.g. on forms) are unchanged; only environment **form migration** option typing is rolled back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cd3497acddd52875cd8fec2ef35b75bc22fff80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->