### PR TITLE
ap-9647 # add unified AIConversation audit record type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-Initial release
+### Added
+
+- `AIConversation` audit record type for unified AI conversations
+- Exported `AuditRecordType` for api and console consumption
+
+### Deprecated
+
+- `AIFormsBuilder`, `AIEnvironmentStylist`, and `AIHelp` audit record types for new writes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-### Added
-
-- `AIConversation` audit record type for unified AI conversations
-- Exported `AuditRecordType` for api and console consumption
-
-### Deprecated
-
-- `AIFormsBuilder`, `AIEnvironmentStylist`, and `AIHelp` audit record types for new writes
+Initial release

--- a/typescript/organisations.d.ts
+++ b/typescript/organisations.d.ts
@@ -38,7 +38,8 @@ export type NewOrganisation = {
    * @deprecated Use `teamMemberMfaRequirement` instead
    *
    *   If `true`, team members will be required to enable multi-factor
-   *   authentication before being able to perform any actions within the organisation.
+   *   authentication before being able to perform any actions within the
+   *   organisation.
    */
   requireTeamMemberMfa?: boolean
   /**
@@ -131,7 +132,7 @@ export type Tier = NewTier & {
   updatedAt: string
 }
 
-export type AuditRecordType =
+type AuditRecordType =
   | 'Organisation'
   | 'OrganisationDeleteRequest'
   | 'OrganisationDataRetention'

--- a/typescript/organisations.d.ts
+++ b/typescript/organisations.d.ts
@@ -131,7 +131,7 @@ export type Tier = NewTier & {
   updatedAt: string
 }
 
-type AuditRecordType =
+export type AuditRecordType =
   | 'Organisation'
   | 'OrganisationDeleteRequest'
   | 'OrganisationDataRetention'
@@ -195,8 +195,25 @@ type AuditRecordType =
   | 'FormVersion'
   | 'FormSubmissionDraft'
   | 'PDFConversion'
+  /**
+   * Unified AI conversations. Mode and target details are carried on `recordId`
+   * rather than separate per-mode audit types.
+   */
+  | 'AIConversation'
+  /**
+   * @deprecated Use `AIConversation` for new writes. Retained for historical
+   *   audit records.
+   */
   | 'AIFormsBuilder'
+  /**
+   * @deprecated Use `AIConversation` for new writes. Retained for historical
+   *   audit records.
+   */
   | 'AIEnvironmentStylist'
+  /**
+   * @deprecated Use `AIConversation` for new writes. Retained for historical
+   *   audit records.
+   */
   | 'AIHelp'
   | 'FormKeyAssociation'
   | 'FormsAppMfaRequirement'


### PR DESCRIPTION
## Requester Checklist

Please only check the items that you have actioned. Do not check items that are not applicable to your PR.

### Implementation

- [ ] Have you tested your implementation locally?
- [ ] If applicable, has an appropriate changelog entry been added? Do not include if you are fixing/changing something that is only in the current release.
- [ ] There are no warnings that have been suppressed unnecessarily
- [ ] Have automated tests been added, or have related ones been updated to cover the change?
- [ ] Have all OneBlink dependency updates been completed (eg apps / apps-react / types etc).
- [ ] Have you ensured this change does not add unwanted dependencies?
- [ ] If this PR contains a refactor, have relevant Jira testing tasks added?
- [ ] Changes that will knowingly make the feature/bug incomplete have been commented with TODO and a description of what needs to be done to finish the feature/bug
- [ ] Any changes made to public APIs have been reflected in the documentation
- [ ] Have you isolated business logic where possible to allow for unit testing?

### Logging and Debugging

- [ ] Are the error messages, if any, informative?
- [ ] Are there enough log events and are they written in a way that allows for easy debugging?
- [ ] "Debugging" code removed
- [ ] Front-end: No erroneous `Console.WriteLines`

### Readability

- [ ] All class, variable, property and method modifiers are provided with the smallest scope possible
- [ ] New files, variables and functions are descriptive/comprehensible and named consistently.
- [ ] There is no dead code (unreachable code)
- [ ] There is no usage of [magic numbers](<https://en.wikipedia.org/wiki/Magic_number_(programming)>)
- [ ] There is no commented out code.
- [ ] In hard-to-understand areas, comments exist and describe rationale or reasons for decisions in code

### Security

- [ ] All personal data inputs are checked (for the correct type, length/size, format, and range).
- [ ] No sensitive information is logged or visible in a stacktrace
- [ ] Are authorization and authentication handled correctly?
- [ ] Is (user) input validated, sanitized, and escaped to prevent security attacks such as cross-site scripting or SQL injection?
- [ ] Is data retrieved from external APIs or libraries checked for security issues?
- [ ] Do API endpoints return appropriate status codes

## Reviewer Guide

- It is important that you understand the purpose of the PR.
- You are encouraged to engage with the requestor if you do not understand any of the proposed code changes/additions/deletions.
- Do you, the reviewer, understand what the code does? Do you think a specific expert, like a security expert or a usability expert, should look over the code before it can be accepted?
- Is a framework, API, library, or service used that should not be used? Are there alternatives you could recommend?
- Are there existing hooks/components/functions in the same code base that could be utilised?
- When reviewing tests, attempt to identify missing edge cases that may be relevant to the proposed implementation
- Ensure you check for:
  - Security
  - Scalability
  - Performance
  - Maintainability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only audit enum extension with backward-compatible deprecated variants; no runtime or security behavior in this diff.
> 
> **Overview**
> Introduces **`AIConversation`** as the single audit record type for AI chats, with mode and target details expected on **`recordId`** instead of separate per-feature audit types.
> 
> Marks **`AIFormsBuilder`**, **`AIEnvironmentStylist`**, and **`AIHelp`** as **deprecated** for new writes while keeping them in the union so existing audit history stays valid.
> 
> Also reformats a **`requireTeamMemberMfa`** JSDoc comment (line wrap only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a7ff4055bbd7949a9d4f70a8e50d3837943c389. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->