### PR TITLE
AP-9801 # Add `FormPaymentEventAmountConfiguration` to payment events

### DIFF
--- a/typescript/submissionEvents.d.ts
+++ b/typescript/submissionEvents.d.ts
@@ -267,6 +267,30 @@ export type CPHCMSSubmissionEvent = FormEventBase & {
   }
 }
 
+/**
+ * Determines the amount to be paid for a payment event. Exactly one of
+ * `elementId`, `paymentAmount`, or `paymentCalculation` must be provided.
+ */
+export type FormPaymentEventAmountConfiguration =
+  | {
+      /**
+       * The elementId that holds the value that will be paid. Must be the id of a
+       * number or calculation element.
+       */
+      elementId: string
+    }
+  | {
+      /** A fixed amount that will be paid. */
+      paymentAmount: number
+    }
+  | {
+      /**
+       * The calculation algorithm that must return a number. Supports the same
+       * syntax as calculation form elements.
+       */
+      paymentCalculation: string
+    }
+
 export type CPPayPaymentDisplayDetailKey =
   | 'CP_PAY_TRANSACTION_ID'
   | 'CP_PAY_ORDER_NUMBER'
@@ -277,12 +301,7 @@ export type CPPayPaymentDisplayDetailKey =
 
 export type CPPaySubmissionEvent = FormEventBase & {
   type: 'CP_PAY'
-  configuration: {
-    /**
-     * The elementId that holds the value that will be paid. Must be the id of a
-     * number or calculation element.
-     */
-    elementId: string
+  configuration: FormPaymentEventAmountConfiguration & {
     /** The id of the OneBlink -> CP Pay integration gateway to be used. */
     gatewayId: string
   }
@@ -301,12 +320,7 @@ export type BPointPaymentDisplayDetailKey =
 
 export type BPOINTSubmissionEvent = FormEventBase & {
   type: 'BPOINT'
-  configuration: {
-    /**
-     * The elementId that holds the value that will be paid. Must be the id of a
-     * number or calculation element.
-     */
-    elementId: string
+  configuration: FormPaymentEventAmountConfiguration & {
     /** The id of the OneBlink -> BPOINT integration environment to be used. */
     environmentId: string
     /** An optional crn string. */
@@ -326,12 +340,7 @@ export type WestpacQuickStreamPaymentDisplayDetailKey =
 
 export type WestpacQuickStreamSubmissionEvent = FormEventBase & {
   type: 'WESTPAC_QUICK_STREAM'
-  configuration: {
-    /**
-     * The elementId that holds the value that will be paid. Must be the id of a
-     * number or calculation element.
-     */
-    elementId: string
+  configuration: FormPaymentEventAmountConfiguration & {
     /** The id of the OneBlink -> WestpacQuickStream integration environment to be used. */
     environmentId: string
     /** A crn string. */
@@ -353,12 +362,7 @@ export type NSWGovPayPaymentDisplayDetailKey =
 
 export type NSWGovPaySubmissionEvent = FormEventBase & {
   type: 'NSW_GOV_PAY'
-  configuration: {
-    /**
-     * The elementId that holds the value that will be paid. Must be the id of a
-     * number or calculation element.
-     */
-    elementId: string
+  configuration: FormPaymentEventAmountConfiguration & {
     /** The id of the OneBlink -> NSW_GOV_PAY integration primary agency to be used. */
     primaryAgencyId: string
     /**

--- a/typescript/submissionEvents.d.ts
+++ b/typescript/submissionEvents.d.ts
@@ -274,7 +274,7 @@ export type CPHCMSSubmissionEvent = FormEventBase & {
 export type FormPaymentEventAmountConfiguration =
   | {
       /** Amount is taken from a form element value. */
-      type?: 'FORM_ELEMENT'
+      amountType?: 'FORM_ELEMENT'
       /**
        * The elementId that holds the value that will be paid. Must be the id of
        * a number or calculation element.
@@ -283,13 +283,13 @@ export type FormPaymentEventAmountConfiguration =
     }
   | {
       /** Amount is a fixed number. */
-      type: 'NUMBER'
+      amountType: 'NUMBER'
       /** A fixed amount that will be paid. */
       paymentAmount: number
     }
   | {
       /** Amount is calculated from an expression. */
-      type: 'EXPRESSION'
+      amountType: 'EXPRESSION'
       /**
        * The calculation algorithm that must return a number. Supports the same
        * syntax as calculation form elements.

--- a/typescript/submissionEvents.d.ts
+++ b/typescript/submissionEvents.d.ts
@@ -273,17 +273,23 @@ export type CPHCMSSubmissionEvent = FormEventBase & {
  */
 export type FormPaymentEventAmountConfiguration =
   | {
+      /** Amount is taken from a form element value. */
+      type?: 'FORM_ELEMENT'
       /**
-       * The elementId that holds the value that will be paid. Must be the id of a
-       * number or calculation element.
+       * The elementId that holds the value that will be paid. Must be the id of
+       * a number or calculation element.
        */
       elementId: string
     }
   | {
+      /** Amount is a fixed number. */
+      type: 'NUMBER'
       /** A fixed amount that will be paid. */
       paymentAmount: number
     }
   | {
+      /** Amount is calculated from an expression. */
+      type: 'EXPRESSION'
       /**
        * The calculation algorithm that must return a number. Supports the same
        * syntax as calculation form elements.


### PR DESCRIPTION
## Requester Checklist

Please only check the items that you have actioned. Do not check items that are not applicable to your PR.

### Implementation

- [ ] Have you tested your implementation locally?
- [ ] If applicable, has an appropriate changelog entry been added? Do not include if you are fixing/changing something that is only in the current release.
- [ ] There are no warnings that have been suppressed unnecessarily
- [ ] Have automated tests been added, or have related ones been updated to cover the change?
- [ ] Have all OneBlink dependency updates been completed (eg apps / apps-react / types etc).
- [ ] Have you ensured this change does not add unwanted dependencies?
- [ ] If this PR contains a refactor, have relevant Jira testing tasks added?
- [ ] Changes that will knowingly make the feature/bug incomplete have been commented with TODO and a description of what needs to be done to finish the feature/bug
- [ ] Any changes made to public APIs have been reflected in the documentation
- [ ] Have you isolated business logic where possible to allow for unit testing?

### Logging and Debugging

- [ ] Are the error messages, if any, informative?
- [ ] Are there enough log events and are they written in a way that allows for easy debugging?
- [ ] "Debugging" code removed
- [ ] Front-end: No erroneous `Console.WriteLines`

### Readability

- [ ] All class, variable, property and method modifiers are provided with the smallest scope possible
- [ ] New files, variables and functions are descriptive/comprehensible and named consistently.
- [ ] There is no dead code (unreachable code)
- [ ] There is no usage of [magic numbers](<https://en.wikipedia.org/wiki/Magic_number_(programming)>)
- [ ] There is no commented out code.
- [ ] In hard-to-understand areas, comments exist and describe rationale or reasons for decisions in code

### Security

- [ ] All personal data inputs are checked (for the correct type, length/size, format, and range).
- [ ] No sensitive information is logged or visible in a stacktrace
- [ ] Are authorization and authentication handled correctly?
- [ ] Is (user) input validated, sanitized, and escaped to prevent security attacks such as cross-site scripting or SQL injection?
- [ ] Is data retrieved from external APIs or libraries checked for security issues?
- [ ] Do API endpoints return appropriate status codes

## Reviewer Guide

- It is important that you understand the purpose of the PR.
- You are encouraged to engage with the requestor if you do not understand any of the proposed code changes/additions/deletions.
- Do you, the reviewer, understand what the code does? Do you think a specific expert, like a security expert or a usability expert, should look over the code before it can be accepted?
- Is a framework, API, library, or service used that should not be used? Are there alternatives you could recommend?
- Are there existing hooks/components/functions in the same code base that could be utilised?
- When reviewing tests, attempt to identify missing edge cases that may be relevant to the proposed implementation
- Ensure you check for:
  - Security
  - Scalability
  - Performance
  - Maintainability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public payment-event configuration types; consumers and runtime must honor new amount modes correctly to avoid wrong charges, though this diff is types-only.
> 
> **Overview**
> Introduces shared **`FormPaymentEventAmountConfiguration`** so payment submission events can define how much to charge in three ways: a form element (`elementId` / optional `FORM_ELEMENT`), a fixed **`paymentAmount`** (`NUMBER`), or an expression string **`paymentCalculation`** (`EXPRESSION`).
> 
> **CP Pay**, **BPOINT**, **Westpac QuickStream**, and **NSW Gov Pay** event configs now intersect this type instead of inlining only `elementId`, so the public types document fixed and calculated amounts alongside the existing element-based amount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32cbf6639a76c5da455d6236b0d29e888c8b8173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->